### PR TITLE
montana: decommonize audio_platform_info.xml and audio_platform_info_…

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<audio_platform_info>
+
+<acdb_ids>
+<!-- Output devices -->
+	<device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="7"/>
+	<device name="SND_DEVICE_OUT_VOICE_HANDSET_TMUS" acdb_id="7"/>
+	<device name="SND_DEVICE_OUT_VOICE_TTY_HCO_HANDSET" acdb_id="7"/>
+	<device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="9"/>
+	<device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" acdb_id="9"/>
+	<device name="SND_DEVICE_OUT_SPEAKER_SAFE_AND_HEADPHONES" acdb_id="9"/>
+	<device name="SND_DEVICE_OUT_VOICE_HEADPHONES" acdb_id="10"/>
+	<device name="SND_DEVICE_OUT_SPEAKER" acdb_id="14"/>
+	<device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="15"/>
+	<device name="SND_DEVICE_OUT_SPEAKER_PROTECTED" acdb_id="14"/>
+	<device name="SND_DEVICE_OUT_SPEAKER_REVERSE" acdb_id="14"/>
+	<device name="SND_DEVICE_OUT_SPEAKER_SAFE" acdb_id="14"/>
+	<device name="SND_DEVICE_OUT_VOICE_SPEAKER_PROTECTED" acdb_id="15"/>
+	<device name="SND_DEVICE_OUT_VOICE_LINE" acdb_id="78"/>
+	<device name="SND_DEVICE_OUT_VOLTE_NB_ANC_HANDSET" acdb_id="200"/>
+	<device name="SND_DEVICE_OUT_VOLTE_NB_HANDSET_TMUS" acdb_id="200"/>
+	<device name="SND_DEVICE_OUT_VOLTE_NB_TX" acdb_id="245" />
+
+<!-- Input devices -->
+	<device name="SND_DEVICE_IN_CAPTURE_VI_FEEDBACK" acdb_id="0"/>
+	<device name="SND_DEVICE_IN_HANDSET_MIC_AEC" acdb_id="4"/>
+	<device name="SND_DEVICE_IN_HANDSET_MIC_AEC_NS" acdb_id="4"/>
+	<device name="SND_DEVICE_IN_HANDSET_MIC_NS" acdb_id="4"/>
+	<device name="SND_DEVICE_IN_VOICE_TTY_VCO_HANDSET_MIC" acdb_id="4"/>
+	<device name="SND_DEVICE_IN_SPEAKER_MIC_AEC" acdb_id="114" />
+	<device name="SND_DEVICE_IN_SPEAKER_MIC_AEC_NS" acdb_id="114" />
+	<device name="SND_DEVICE_IN_SPEAKER_MIC_NS" acdb_id="114" />
+	<device name="SND_DEVICE_IN_VOICE_REC_DMIC_FLUENCE" acdb_id="35"/>
+	<device name="SND_DEVICE_IN_VOICE_DMIC_TMUS" acdb_id="41"/>
+	<device name="SND_DEVICE_IN_VOICE_SPEAKER_MIC" acdb_id="42" />
+	<device name="SND_DEVICE_IN_HEADSET_MIC_AEC" acdb_id="47"/>
+	<device name="SND_DEVICE_IN_VOICE_REC_MIC_NS" acdb_id="62"/>
+	<device name="SND_DEVICE_IN_HANDSET_DMIC_AEC" acdb_id="111"/>
+	<device name="SND_DEVICE_IN_HANDSET_DMIC_NS" acdb_id="111"/>
+	<device name="SND_DEVICE_IN_VOICE_REC_HEADSET_MIC" acdb_id="131"/>
+	<device name="SND_DEVICE_IN_CAPTURE_FM" acdb_id="90"/>
+</acdb_ids>
+
+<pcm_ids>
+	<usecase name="USECASE_AUDIO_PLAYBACK_LOW_LATENCY" type="out" id="12"/>
+	<usecase name="USECASE_AUDIO_RECORD_LOW_LATENCY" type="in" id="12"/>
+	<usecase name="USECASE_VOICEMMODE1_CALL" type="in" id="34"/>
+	<usecase name="USECASE_VOICEMMODE1_CALL" type="out" id="34"/>
+	<usecase name="USECASE_VOICEMMODE2_CALL" type="in" id="35"/>
+	<usecase name="USECASE_VOICEMMODE2_CALL" type="out" id="35"/>
+	<usecase name="USECASE_VOLTE_CALL" type="in" id="15"/>
+	<usecase name="USECASE_VOLTE_CALL" type="out" id="15"/>
+	<usecase name="USECASE_VOWLAN_CALL" type="in" id="16"/>
+	<usecase name="USECASE_VOWLAN_CALL" type="out" id="16"/>
+	<usecase name="USECASE_AUDIO_DSM_FEEDBACK" type="in" id="55" />
+</pcm_ids>
+
+<backend_names>
+	<device name="SND_DEVICE_OUT_SPEAKER" backend="speaker" />
+	<device name="SND_DEVICE_OUT_VOICE_SPEAKER" backend="speaker" />
+	<device name="SND_DEVICE_OUT_VOLTE_NB_SPEAKER" backend="speaker" />
+	<device name="SND_DEVICE_OUT_SPEAKER_SAFE" backend="speaker" />
+	<device name="SND_DEVICE_OUT_SPEAKER_REVERSE" backend="speaker" />
+	<device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" backend="speaker-and-headphones" />
+	<device name="SND_DEVICE_OUT_SPEAKER_AND_LINE" backend="speaker-and-headphones" />
+	<device name="SND_DEVICE_OUT_SPEAKER_SAFE_AND_HEADPHONES" backend="speaker-and-headphones" />
+	<device name="SND_DEVICE_OUT_SPEAKER_SAFE_AND_LINE" backend="speaker-and-headphones" />
+</backend_names>
+
+</audio_platform_info>

--- a/audio/audio_platform_info_extcodec.xml
+++ b/audio/audio_platform_info_extcodec.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Copyright (c) 2015, The Linux Foundation. All rights reserved.         -->
+<!--                                                                        -->
+<!-- Redistribution and use in source and binary forms, with or without     -->
+<!-- modification, are permitted provided that the following conditions are -->
+<!-- met:                                                                   -->
+<!--     * Redistributions of source code must retain the above copyright   -->
+<!--       notice, this list of conditions and the following disclaimer.    -->
+<!--     * Redistributions in binary form must reproduce the above          -->
+<!--       copyright notice, this list of conditions and the following      -->
+<!--       disclaimer in the documentation and/or other materials provided  -->
+<!--       with the distribution.                                           -->
+<!--     * Neither the name of The Linux Foundation nor the names of its    -->
+<!--       contributors may be used to endorse or promote products derived  -->
+<!--       from this software without specific prior written permission.    -->
+<!--                                                                        -->
+<!-- THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED           -->
+<!-- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF   -->
+<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT -->
+<!-- ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS -->
+<!-- BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR -->
+<!-- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   -->
+<!-- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR        -->
+<!-- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,  -->
+<!-- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN -->
+<!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          -->
+<audio_platform_info>
+    <bit_width_configs>
+        <device name="SND_DEVICE_OUT_SPEAKER" bit_width="24"/>
+    </bit_width_configs>
+    <interface_names>
+        <device name="AUDIO_DEVICE_IN_BUILTIN_MIC" interface="SLIMBUS_0" codec_type="external"/>
+        <device name="AUDIO_DEVICE_IN_BACK_MIC" interface="SLIMBUS_0" codec_type="external"/>
+        <device name="AUDIO_DEVICE_IN_BUILTIN_MIC" interface="TERT_MI2S" codec_type="internal"/>
+        <device name="AUDIO_DEVICE_IN_BACK_MIC" interface="TERT_MI2S" codec_type="internal"/>
+    </interface_names>
+    <pcm_ids>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD2" type="out" id="24"/>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD3" type="out" id="29"/>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD4" type="out" id="30"/>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD5" type="out" id="31"/>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD6" type="out" id="32"/>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD7" type="out" id="33"/>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD8" type="out" id="34"/>
+        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD9" type="out" id="35"/>
+        <usecase name="USECASE_VOICEMMODE1_CALL" type="in" id="35"/>
+        <usecase name="USECASE_VOICEMMODE1_CALL" type="out" id="35"/>
+        <usecase name="USECASE_VOICEMMODE2_CALL" type="in" id="36"/>
+        <usecase name="USECASE_VOICEMMODE2_CALL" type="out" id="36"/>
+        <usecase name="USECASE_AUDIO_SPKR_CALIB_TX" type="in" id="37"/>
+    </pcm_ids>
+    <config_params>
+        <param key="spkr_1_tz_name" value="wsatz.11"/>
+        <param key="spkr_2_tz_name" value="wsatz.12"/>
+        <param key="native_audio_mode" value="src"/>
+    </config_params>
+</audio_platform_info>
+

--- a/device.mk
+++ b/device.mk
@@ -23,7 +23,9 @@ $(call inherit-product, device/motorola/montana/system_prop.mk)
 
 # Audio
 PRODUCT_COPY_FILES +=  \
-    $(LOCAL_PATH)/configs/mixer_paths.xml:$(TARGET_COPY_OUT_VENDOR)/etc/mixer_paths.xml
+    $(LOCAL_PATH)/configs/mixer_paths.xml:system/vendor/etc/mixer_paths.xml
+    $(LOCAL_PATH)/audio/audio_platform_info_extcodec.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_platform_info_extcodec.xml \
+    $(LOCAL_PATH)/audio/audio_platform_info.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_platform_info.xml
 
 # Camera
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
…extcodec.xml

 * montana uses different ACDB ids than other devices which is causing issues for devices such as perry (and most likely owens).